### PR TITLE
Hotfix for module named like "is-function"

### DIFF
--- a/lib/typer.js
+++ b/lib/typer.js
@@ -157,7 +157,7 @@ var tree = require("./tree");
 	};
 
 module.exports = {
-	tokens: ["\\?", "\\!", "function", "\\.\\.\\.", ",", "\\:", "\\|", "="],
+	tokens: ["\\?", "\\!", "(?:[^\\-]|^)function", "\\.\\.\\.", ",", "\\:", "\\|", "="],
 	process: process,
 	type: function(str){
 		return process(this.tree(str), {});


### PR DESCRIPTION
New "function" regex:

https://regex101.com/r/jL1iW6/8/tests

```js
const regex = /(?:[^\-]|^)function/gm;
const str = `is-function`;
let m;

while ((m = regex.exec(str)) !== null) {
    // This is necessary to avoid infinite loops with zero-width matches
    if (m.index === regex.lastIndex) {
        regex.lastIndex++;
    }
    
    // The result can be accessed through the `m`-variable.
    m.forEach((match, groupIndex) => {
        console.log(`Found match, group ${groupIndex}: ${match}`);
    });
}
```

Without this, "can-util/js/is-function/is-function" stops short at "can-util/js/is-function":

![image](https://user-images.githubusercontent.com/990216/28668157-360ffa0c-7294-11e7-81f3-b3a40654efd0.png)

With new `(?:[^\-]|^)function` regex:

![image](https://user-images.githubusercontent.com/990216/28668499-b367739e-7295-11e7-94dd-9ea053aa83fe.png)

@justinbmeyer Is there a better solution? Feels like a temporary fix; but best I could come up with.